### PR TITLE
fix: tuning nav-menu style

### DIFF
--- a/src/plugin/styles/app.scss
+++ b/src/plugin/styles/app.scss
@@ -69,12 +69,13 @@
       border-right: 0;
       flex: 1;
       overflow-y: auto;
+      margin-bottom: 80px;
     }
 
     .render-nav-btn {
       position: absolute;
       bottom: 40px;
-      width: 220px;
+      width: 100%;
       height: 40px;
       background: white;
     }


### PR DESCRIPTION
https://trello.com/c/Yt3Q2B2Z/978-1-菜单栏-无法滚动到最底部